### PR TITLE
If available, use system pipework, else bundled.

### DIFF
--- a/lib/vagrant-lxc/command/sudoers.rb
+++ b/lib/vagrant-lxc/command/sudoers.rb
@@ -48,7 +48,7 @@ module Vagrant
               'sudoers.rb',
               :template_root  => Vagrant::LXC.source_root.join('templates').to_s,
               :cmd_paths      => build_cmd_paths_hash,
-              :pipework_regex => "#{ENV['HOME']}/\.vagrant\.d/gems/gems/vagrant-lxc.+/scripts/pipework"
+              :pipework_regex => "\\A" + ( `which pipework`.to_s.strip[/.+/m] || "#{ENV['HOME']}/\\.vagrant\\.d/gems/gems/vagrant-lxc.+/scripts/pipework" )
             )
             file.puts template.render
           end

--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -151,7 +151,7 @@ module Vagrant
         end
 
         cmd = [
-          Vagrant::LXC.source_root.join('scripts/pipework').to_s,
+          `which pipework`.to_s.strip[/.+/m] || Vagrant::LXC.source_root.join('scripts/pipework').to_s,
           bridge_name,
           container_name,
           ip ||= "dhcp"


### PR DESCRIPTION
The bundled script is in the user's home directory. If pipework is on
the system, prefer using that over sudo-ing a user editable script.
